### PR TITLE
	Overriding StringTable keys for DataAnnotations

### DIFF
--- a/source/Griffin.MvcContrib/Localization/ResourceStringProvider.cs
+++ b/source/Griffin.MvcContrib/Localization/ResourceStringProvider.cs
@@ -96,7 +96,7 @@ namespace Griffin.MvcContrib.Localization
         /// </remarks>
         public string GetValidationString(Type attributeType)
         {
-            var name = attributeType.Name.Replace("Attribute", "");
+            var name = Format(attributeType);
             return GetString(name);
         }
 
@@ -125,6 +125,16 @@ namespace Griffin.MvcContrib.Localization
         {
             var baseStr = string.Format("{0}_{1}", type.Name, propertyName);
             return extras.Aggregate(baseStr, (current, extra) => current + ("_" + extra));
+        }
+
+        /// <summary>
+        /// Format the attribute type information into a StringTable key
+        /// </summary>
+        /// <param name="attributeType">Attribute type</param>
+        /// <returns>String Table key</returns>
+        protected virtual string Format(Type attributeType)
+        {
+            return attributeType.Name.Replace("Attribute", "");
         }
 
         /// <summary>


### PR DESCRIPTION
Added a virtual method to enable overriding of StringTable keys for localized error messages for DataAnnotation attributes. Now StringTable keys for both model information and error messages can be changed in a derived class.
