### PR TITLE
Update source/Griffin.MvcContrib/Plugins/RoutedMenuItem.cs

### DIFF
--- a/source/Griffin.MvcContrib/Plugins/RoutedMenuItem.cs
+++ b/source/Griffin.MvcContrib/Plugins/RoutedMenuItem.cs
@@ -61,7 +61,6 @@ namespace Griffin.MvcContrib.Plugins
             var routeName = (string)_route["area"];
             if (routeName != null)
             {
-                _route.Remove("area");
                 return new Uri(helper.RouteUrl(routeName, _route), UriKind.Relative);
             }
 


### PR DESCRIPTION
Area shouldn't be deleted because routes are only registered once per application lifecycle, but added to the menu every time a page is requested.
