### PR TITLE
password question and password answer must be set before calling Registe...

### DIFF
--- a/source/Griffin.MvcContrib/Providers/Membership/MembershipProvider.cs
+++ b/source/Griffin.MvcContrib/Providers/Membership/MembershipProvider.cs
@@ -276,6 +276,9 @@ namespace Griffin.MvcContrib.Providers.Membership
             var passwordInfo = new AccountPasswordInfo(username, password);
             account.Password = PasswordStrategy.Encrypt(passwordInfo);
             account.PasswordSalt = passwordInfo.PasswordSalt;
+            
+            account.PasswordAnswer = passwordAnswer;
+            account.PasswordQuestion = passwordQuestion;
 
             status = AccountRepository.Register(account);
             if (status == MembershipCreateStatus.Success)


### PR DESCRIPTION
...r of AccountRepository

I have set IsPasswordQuestionRequired in PasswordPolicy to true. but when MembershipProvider calls Register of AccountRepository Password question and answer are both null. While I have passed them to membership provider through calling Membership.CreateUser.
